### PR TITLE
feat: use fastlane env for IPA path

### DIFF
--- a/lib/fastlane/plugin/shorebird/actions/shorebird_release_action.rb
+++ b/lib/fastlane/plugin/shorebird/actions/shorebird_release_action.rb
@@ -5,7 +5,18 @@ module Fastlane
   module Actions
     class ShorebirdReleaseAction < Action
       def self.run(params)
-        Fastlane::Actions.sh("shorebird release #{params[:platform]} #{params[:args]}".strip)
+        platform = params[:platform]
+        Fastlane::Actions.sh("shorebird release #{platform} #{params[:args]}".strip)
+
+        if platform == "ios"
+          # Get the most recently-created IPA file
+          ipa_file = Dir.glob('../build/ios/ipa/*.ipa')
+                        .sort_by! { |f| File.stat(f).ctime }
+                        .reverse!
+                        .first
+          puts("Setting IPA_OUTPUT_PATH to #{ipa_file}")
+          lane_context[SharedValues::IPA_OUTPUT_PATH] = ipa_file
+        end
       end
 
       def self.description

--- a/spec/shorebird_release_action_spec.rb
+++ b/spec/shorebird_release_action_spec.rb
@@ -19,5 +19,19 @@ describe Fastlane::Actions::ShorebirdReleaseAction do
       expect(Fastlane::Actions).to receive(:sh).with("shorebird release android -- --build-name=1.0.0")
       Fastlane::Actions::ShorebirdReleaseAction.run(platform: "android", args: "-- --build-name=1.0.0")
     end
+
+    it 'adds IPA_OUTPUT_PATH to lane context if platform is ios' do
+      old_ipa_file = instance_double('File', path: 'old.ipa')
+      new_ipa_file = instance_double('File', path: 'new_ipa')
+
+      allow(Fastlane::Actions).to receive(:sh).with("shorebird release ios")
+      allow(Dir).to receive(:glob).with('../build/ios/ipa/*.ipa').and_return([old_ipa_file.path, new_ipa_file.path])
+      allow(File).to receive(:stat).with(old_ipa_file.path).and_return(instance_double('File::Stat', ctime: Time.now - 100))
+      allow(File).to receive(:stat).with(new_ipa_file.path).and_return(instance_double('File::Stat', ctime: Time.now - 10))
+
+      Fastlane::Actions::ShorebirdReleaseAction.run(platform: "ios")
+
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::IPA_OUTPUT_PATH]).to eq(new_ipa_file.path)
+    end
   end
 end


### PR DESCRIPTION
Finds the most recently-created IPA file in the `build/ios/ipa` directory and sets `IPA_OUTPUT_PATH` to that file's path. See https://docs.fastlane.tools/advanced/lanes/#lane-context

Fixes https://github.com/shorebirdtech/fastlane-plugin-shorebird/issues/1